### PR TITLE
back action open/close drawer

### DIFF
--- a/app/src/main/java/com/termux/app/TermuxActivity.java
+++ b/app/src/main/java/com/termux/app/TermuxActivity.java
@@ -588,8 +588,8 @@ public final class TermuxActivity extends AppCompatActivity implements ServiceCo
     public void onBackPressed() {
         if (getDrawer().isDrawerOpen(Gravity.LEFT)) {
             getDrawer().closeDrawers();
-        } else {
-            finishActivityIfNotFinishing();
+        } else if (!getDrawer().isDrawerOpen(Gravity.LEFT)) {
+            getDrawer().openDrawer(Gravity.LEFT);
         }
     }
 


### PR DESCRIPTION
The home action already leave the app

This is similar to citra and other apps that use a drawer

Just disable it completely and use home or other actions to switch apps

I could never use the drawer even before android 11 anyway

Something with the way it opens

Like glitching through Zelda ds very specific motions required 