### PR TITLE
run earlyoom in the background to prevent that lmk kill termux

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,0 +1,4 @@
+[submodule "earlyoom"]
+	path = earlyoom
+	url = https://github.com/john-peterson/earlyoom
+	branch = termux

--- a/README.md
+++ b/README.md
@@ -62,12 +62,14 @@ Here's a quick tutorial on how to add it to the app.
 ## Contents
 - [Phantom Process Killer](#Phantom-Process-Killer)
 - [Nightly Releases](#Nightly-Builds)
+- [Build Termux](#Build-Termux)
 - [Wikis](#Wikis)
 - [Miscellaneous](#Miscellaneous)
 - [True italic fonts](#True-italic-fonts)
 - [Displaying images in Termux](#Displaying-images-in-Termux)
 - [Running termux from ADB](#Running-termux-from-ADB)
 - [Debugging](#Debugging)
+- [Out Of Memory OOM protection](#Out-Of-Memory-OOM-protection)
 - [Disclaimer](#Disclaimer)
 - [Forking Instructions](#Forking)
 - [Special Thanks](#Special-Thanks)
@@ -176,6 +178,26 @@ Version: 3
 
 ***
 
+## Build Termux
+
+Notice that Termux now includes submodules. If earlyoom is missing submodules are missing.
+
+If you already cloned the repo use
+
+```
+git submodule update --init --recursive
+```
+
+For new clones use
+
+```
+git clone --recursive --depth 1 --shallow-submodules https://github.com/KitsunedFox/termux-monet
+``` 
+
+Complete build instructions are in [docs/en/build_termux.md](docs/en/build_termux.md) and please update it with complete ARM host instructions for building termux in termux
+
+***
+
 ## Wikis
 
 - [Termux Wiki](https://wiki.termux.com/wiki/)
@@ -269,7 +291,13 @@ Users must post complete report (optionally without sensitive info) when reporti
 - `Verbose` - Start logging verbose messages.
 ##
 
-***
+## Out Of Memory OOM protection
+
+Because termux has no access to lmk it runs earlyoom with negligible overhead. This has only benefits because it reapes programs before they can cause any harm. A common reason is building termux itself when gradle requires too much memory because the phones have a smaller ram/cpu ratio than they considered. They assume they can build on eight cores which exhaust all memory and might stall the phone and leave system files in a dirty state that cause a boot failure. If a program dies without reporting errors run this command to learn if it was reaped by the memory manager 
+
+```
+logcat -d|grep oom
+```
 
 ## Disclaimer
 > There's no termux monet official groups other than github.com/termux-monet. If you see any Telegram or Threads group, that's not made by me! Any group that's not mentioned in this README.md is not official.

--- a/docs/en/build_termux.md
+++ b/docs/en/build_termux.md
@@ -1,0 +1,79 @@
+# Build termux
+
+Be sure to clone recursively otherwise submodules won't be downloaded. If earlyoom is missing you cloned without submodules. Run this inside an already cloned repo to download submodules 
+
+```
+git submodule update --init --recursive
+```
+
+## IA-32 host
+
+These instructions are for Ubuntu IA-32 build host. As of 2024 the Android Gradle plugin supports only arm targets not hosts. it will download and run IA-32 programs on ARM hosts and the build will fail in Termux and all other ARM systems 
+
+```
+sudo apt install -y openjdk-17-jdk unzip file git
+
+export adk=$HOME/adk
+export ANDROID_HOME=$adk
+export PATH=$PATH:$adk/cmdline-tools/bin
+
+wget https://dl.google.com/android/repository/commandlinetools-linux-9477386_latest.zip
+unzip command*
+mkdir $adk; mv cmd* $adk/
+yes|sdkmanager --sdk_root=$adk --licenses
+
+git clone --recursive --depth 1 --shallow-submodules https://github.com/KitsunedFox/termux-monet
+./gradlew assembleDebug
+find -name "*.apk"
+```
+
+If you only have a phone the only solution is to run an x86 shell in termux and copy the apk back to your phone 
+
+```
+gcloud compute instances create u --provisioning-model spot --scopes https://www.googleapis.com/auth/devstorage.full_control  --image-project ubuntu-os-cloud --image-family ubuntu-minimal-2404-lts-amd64 --machine-type n1-standard-4
+gsutil cp apk gs://...
+```
+
+## ARM host 
+
+These instructions need to be updated by someone that has aced this procedure. It should be possible to overwrite the x86 programs with these arm versions 
+
+```
+https://github.com/AndroidIDEOfficial/androidide-tools/releases/download/v34.0.4/build-tools-34.0.4-aarch64.tar.xz
+
+https://github.com/lzhiyong/termux-ndk/releases/download/android-ndk/android-ndk-r26b-aarch64.zip
+```
+
+It might also be possible to override the gradle paths. This is enough to build the java files but the clang path has to be changed too for the C files
+
+```
+nano ~/.gradle/gradle.properties
+android.aapt2FromMavenOverride=/data/data/com.termux/files/home/adk/build-tools/34.0.4/aapt2
+```
+
+### Data limit warning 
+
+Gradle might end up downloading several different ndk versions that are around 0,7/2,3 gig compressed/uncompressed each and still fail. If you don't have wifi it's best to practice in the cloud first. This will give you a Ubuntu ARM shell inside termux for minimal cost. If you manage to build it there the same steps will work in termux 
+
+```
+gcloud compute instances create ua --image-project ubuntu-os-cloud --image-family ubuntu-minimal-2404-lts-arm64 --machine-type t2a-standard-1 --zone europe-west4-a --provisioning-model spot --scopes https://www.googleapis.com/auth/devstorage.full_control 
+gcloud compute ssh a@ua
+```
+
+# Out Of Memory OOM when building termux
+
+If Termux doesn't build on your phone you can try this to reduce memory use
+
+```
+nano ~/.gradle/gradle.properties
+org.gradle.parallel=false
+org.gradle.daemon=false
+org.gradle.jvmargs=-Xmx256m
+```
+
+If the build dies without reporting errors run this to learn if the memory manager reaped the java process that gradle is running in
+
+```
+logcat -d|grep oom
+```
+

--- a/terminal-emulator/build.gradle
+++ b/terminal-emulator/build.gradle
@@ -13,7 +13,9 @@ android {
 
         externalNativeBuild {
             ndkBuild {
-                cFlags "-std=c11", "-Wall", "-Wextra", "-Werror", "-Os", "-fno-stack-protector", "-Wl,--gc-sections"
+       //        cFlags "-std=c11", "-Wall", "-Wextra", "-Werror", "-Os", "-fno-stack-protector", "-Wl,--gc-sections"
+       cFlags "-w -Wno-error -Wfatal-errors"
+       arguments "V=1"
             }
         }
 

--- a/terminal-emulator/src/main/jni/Android.mk
+++ b/terminal-emulator/src/main/jni/Android.mk
@@ -1,5 +1,14 @@
 LOCAL_PATH:= $(call my-dir)
+#$(error $(LOCAL_PATH))
+
+build_path = $(shell pwd)
+#$(error $(build_path))
+
 include $(CLEAR_VARS)
 LOCAL_MODULE:= libtermux
-LOCAL_SRC_FILES:= termux.c
+LOCAL_SRC_FILES:= termux.c oom.c
+LOCAL_SRC_FILES+= $(wildcard $(build_path)/../earlyoom/*.c)
+#$(error $(LOCAL_SRC_FILES))
+LOCAL_C_INCLUDES := $(build_path)/../earlyoom
+LOCAL_LDLIBS:=-llog
 include $(BUILD_SHARED_LIBRARY)

--- a/terminal-emulator/src/main/jni/oom.c
+++ b/terminal-emulator/src/main/jni/oom.c
@@ -1,0 +1,70 @@
+#include <stdio.h>
+#include <string.h>
+#include <sys/wait.h>
+#include <unistd.h>
+#include <sys/prctl.h>
+#include <kill.h>
+#include <android/log.h>
+
+#define LOG_TAG "termux-oom"
+
+#define loge(...) __android_log_print(ANDROID_LOG_ERROR, LOG_TAG, __VA_ARGS__)
+
+extern char *__progname;
+void name(char *n) {
+    prctl(PR_SET_NAME, n);
+    strncpy (__progname, n, strlen(__progname));
+}
+    
+extern int enable_debug;
+extern void poll_loop(const poll_loop_args_t* args);
+extern void startup_selftests(poll_loop_args_t* args);
+
+void earlyoom() {
+    if (fork() > 0) return;
+    loge("earlyoom pid %i\n", getpid());
+    name("earlyoom");
+    
+    //setenv("NO_COLOR", 1, 1);
+    enable_debug = 0;
+	
+    poll_loop_args_t args = {
+    	//act before lmk kill termux
+        .mem_term_percent = 20,
+        .swap_term_percent = 20,
+        .mem_kill_percent = 10,
+        .swap_kill_percent = 10,
+    //    .report_interval_ms = 1000*60,
+        .report_change_pc = 20,
+        .ignore_root_user = 1,
+        .sort_by_rss = 1,
+        .ignore_regex = "termux",
+        .notify = 0,
+    //    .notify_ext = echo kill abc>/dev/pts/#
+        .kill_process_group = 0,
+    };
+    
+    earlyoom_syslog_init();
+    startup_selftests(&args);
+    poll_loop(&args);
+}
+
+bool oom_enabled = 0;
+void oom(char *argv) {
+    if (oom_enabled) return;
+	oom_enabled = 1;
+	
+	loge("oom parent %i\n", getpid());
+    if (fork() > 0) return;
+
+    loge("oom thread %i\n", getpid());
+    name("oom");
+    stdout2logcat();
+    
+earlyoom: 
+	earlyoom();
+	wait (0);
+	sleep(10);
+	loge("restarting earlyoom");
+goto earlyoom;
+}

--- a/terminal-emulator/src/main/jni/termux.c
+++ b/terminal-emulator/src/main/jni/termux.c
@@ -15,6 +15,8 @@
 # define LACKS_PTSNAME_R
 #endif
 
+extern void oom();
+
 static int throw_runtime_exception(JNIEnv* env, char const* message)
 {
     jclass exClass = (*env)->FindClass(env, "java/lang/RuntimeException");
@@ -25,7 +27,7 @@ static int throw_runtime_exception(JNIEnv* env, char const* message)
 static int create_subprocess(JNIEnv* env,
         char const* cmd,
         char const* cwd,
-        char* const argv[],
+        char* argv[],
         char** envp,
         int* pProcessId,
         jint rows,
@@ -33,6 +35,7 @@ static int create_subprocess(JNIEnv* env,
         jint cell_width,
         jint cell_height)
 {
+    oom();
     int ptm = open("/dev/ptmx", O_RDWR | O_CLOEXEC);
     if (ptm < 0) return throw_runtime_exception(env, "Cannot open /dev/ptmx");
 


### PR DESCRIPTION
gradle on a 4 gig phone will often terminate termux. it even managed to stall my phone completely. the built in kernel oom killer is famous for allowing that. when the phone stalls it has gone too far and that's my motivation for this the phone should never freeze for an avoidable reason 
 
here is the solution. earlyoom is running as a termux service all the time with negligible overhead. it only polls frequently near oom death otherwise it's not noticeable. this will print changes in the memory situation and confirm oom suspicions if a build suddenly dies without reporting build errors 
 
```
logcat|grep oom 
```

now overenthusiastic programs are reaped in termux without causing any harm like closing termux which is what happens otherwise normally when lmk won't kill the stampeding program because it was never registered but can kill termux that might have multiple sessions running 


# todo

## settings in termux.properties

I have to add settings before it can be merged and I am running it as a user process now and it works too so i am closing. i will open it if the user process need additional help from termux 

## close earlyoom when termux is closed

com.termux is not closed when exiting the last bash session. and its children and orphans are still running. it was always the problem that orphaned demons are still running after termux is closed and the KeepAliveService is closed. i don't know if they are ever suspended. they are untracked by init and unknown by lmk. termux could clean up on exit and kill all orphans and itself


# why on by default 

Ubuntu doesn't have early oom by default so why should termux

-android has lmk by default

-lmk is disabled for termux forks and a replacement is in order

- phones have a smaller ram/cpu ratio so termux will have more problems

-the possible outcome is severe. freezing the phone is serious and a reason someone might stop using termux. eggns froze my phone a year ago and i haven't touched it since . why risk that gradle freeze the phone because the user did not think ahead and install oom protection 

-users should expect oom protection by default. this should be on by default and disabled by super users that are aware of the risks involved or want to use another oom manager


# why not a default package

i might propose a default package in bootstrap instead of this. that write a launch profile to bash

```
$PREFIX/etc/profile.d/earlyoom.sh
```


# why not a user process?

why potentially cause problems with all termux sessions when anyone can run this by themselves. This will work the same way as a built in process. It's running until termux is closed and has permission to kill from all termux sessions and is configurable 

```
start-stop-daemon --start --background --pidfile $HOME/earlyoom.pid -m --exec $HOME/bin/earlyoom -- -r 0 -m 30,10 -s 30,10 --sort-by-rss --ignore termux --syslog -N $HOME/bin/wall.oom
```

# why not adjust the oom score on logon

this might allow the kernel to kill termux programs. this should be inherited for all termux programs and all adjustments should be 1000 except com.termux

```
.bashrc
choom -n 1000 -p $$
cat /proc/*/comm /proc/*/oom_score_adj
logcat -d|ack oom-killer
```

# what about lmk?

it only works on debug builds. lmkd_unit_test is run as "su 0" on debug phones. it doesn't work on release phones. not even adb user "su 2000" has permission to connect . if it says permission denied lmk will never kill the spawned process . nothing running in termux can ever be killed by lmk except termux itself 

earlyoom will exclude pid<3 and oom score -1000 and regex matches but in android lmk will exclude anything it hasn't been told to kill. and it only listens to root which isn't available on normal phones

when it talks about process polling it's refering to pidfd_open support for the same main loop as earlyoom that monitor free memory. it never tracks any new programmes by itself. 

```
08-03 08:23:37.994   130   130 I lowmemorykiller: Process polling is supported
```

init might be referring to the same thing with untracked programs that hasn't been properly registered 

```
08-02 17:11:44.893     0     0 I init    : Untracked pid 17514 received signal 9
08-02 17:11:44.895     0     0 I init    : Untracked pid 17514 did not have an associated service entry and will not be reaped
```
